### PR TITLE
Increase timeout to 10s while we develop

### DIFF
--- a/src/graphhopper/client.js
+++ b/src/graphhopper/client.js
@@ -8,7 +8,7 @@ const {
 
 const client = axios.create({
   baseURL: `${PROTOCOL}://${GRAPHHOPPER_SERVICE_NAME}.${NAMESPACE}.${HOSTNAME}/`,
-  timeout: 2000
+  timeout: 10 * 1000
 });
 
 module.exports = client;


### PR DESCRIPTION
We've been getting sporadic timeouts from graphopper due to the timeout being a tad low.  `route-pt` in particular seems to take longer than a standard `route`.

```
[1645044819193] ERROR (1 on graphhopper-fascade-deployment-85546957fc-g7j5x): timeout of 2000ms exceeded
```