### PR TITLE
Logging improvements

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -12,9 +12,7 @@ import { router as nominatimRouter } from './nominatim/index.js';
 import { router as fileRouter } from './file/index.js';
 
 const httpLogger = pinoHttp({
-  transport: {
-    target: 'pino-http-print'
-  }
+  logger: logger,
 });
 const app = express();
 

--- a/src/lib/logger.js
+++ b/src/lib/logger.js
@@ -1,9 +1,15 @@
 import pino from 'pino';
 
+const debugMode = process.env.NODE_ENV !== 'production';
+
 const logger = pino({
-  transport: {
-    target: 'pino-http-print'
-  }
+  transport: debugMode ? {
+    target: 'pino-http-print',
+    options: {
+      all: true,
+      translateTime: true,
+    },
+  } : null,
 });
 
 export default logger;


### PR DESCRIPTION
- Allow the use of logger.info(), logger.error() etc without swallowing up these messages silently. Fixes #14
- In production, use the standard JSON log lines instead of pretty-printing, which pino only recommends doing for development mode. (@Andykmcc will this change break anything?)

Logging examples (note: this includes log lines I've added in a dev branch, not on main):
![Screenshot from 2023-03-11 21-55-09](https://user-images.githubusercontent.com/1730853/224527303-41712a6d-19e4-4409-85bb-f2e9737070d7.png)

(Don't worry, the coordinates in that screenshot are public amenities and not my house.)