### PR TITLE
geoconfig: only read transit-service-area.json

### DIFF
--- a/src/geoconfig/router.js
+++ b/src/geoconfig/router.js
@@ -1,51 +1,35 @@
 import express from 'express';
-import { extname, join, parse } from 'node:path';
-import { readdir, readFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { readFile } from 'node:fs/promises';
 import {
   REGION_CONFIG,
   WEB_APP_GEO_CONFIG_FOLDER_CONTAINER_PATH,
 } from '../config.js';
 
 const router = express.Router();
-let geoConfigsCache = null;
-
-async function readGeoConfigs() {
-  if (geoConfigsCache) return geoConfigsCache;
-
-  const fileNames = (await readdir(WEB_APP_GEO_CONFIG_FOLDER_CONTAINER_PATH)).filter(f => {
-    return extname(join(WEB_APP_GEO_CONFIG_FOLDER_CONTAINER_PATH, f)) === '.json';
-  });
-
-  const readingFiles = [];
-  for (const fileName of fileNames) {
-    readingFiles.push(readFile(join(WEB_APP_GEO_CONFIG_FOLDER_CONTAINER_PATH, fileName), { encoding: 'utf8' }));
-  }
-
-  const fileBuffers = await Promise.all(readingFiles);
-
-  const geoConfigs = fileNames.reduce((accum, fileName, i) => {
-    accum[parse(fileName).name] = JSON.parse(fileBuffers[i]);
-    return accum;
-  }, {});
-
-  if (process.env.NODE_ENV !== 'development') {
-    geoConfigsCache = geoConfigs;
-  }
-
-  return geoConfigs;
-}
+let transitServiceAreaCache = null;
 
 router.get('/', async (req, res) => {
-  let geoConfigs;
-  try {
-    geoConfigs = await readGeoConfigs();
-  } catch (err) {
-    console.warn('failed to read geoconfigs', err);
+  let transitServiceArea = transitServiceAreaCache;
+  if (!transitServiceArea) {
+    try {
+      const fileContents = await readFile(join(
+        WEB_APP_GEO_CONFIG_FOLDER_CONTAINER_PATH,
+        'transit-service-area.json',
+      ), { encoding: 'utf8' });
+      transitServiceArea = JSON.parse(fileContents);
+
+      if (process.env.NODE_ENV !== 'development') {
+        transitServiceAreaCache = transitServiceArea;
+      }
+    } catch (err) {
+      console.warn('failed to read transit service area', err);
+    }
   }
 
   const config = {...REGION_CONFIG};
-  if (geoConfigs && 'transit-service-area' in geoConfigs) {
-    config.transitServiceArea = geoConfigs['transit-service-area'];
+  if (transitServiceArea) {
+    config.transitServiceArea = transitServiceArea;
   }
   delete config.gtfsRtUrls; // Not used in frontend (can't be, would expose token)
 


### PR DESCRIPTION
We do not use any other files right now, so we don't need to read the whole directory.