### PR TITLE
serve up route tiles from a static express endpoint

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -5,7 +5,7 @@ import pinoHttp from 'pino-http';
 import { satisfies } from 'compare-versions';
 
 import logger from './lib/logger.js';
-import { PORT as port } from './config.js';
+import { WEB_APP_GEO_CONFIG_FOLDER_CONTAINER_PATH, PORT as port } from './config.js';
 
 import { router as graphHopperRouter } from './graphhopper/index.js';
 import { router as photonRouter } from './photon/index.js';
@@ -13,6 +13,7 @@ import { router as nominatimRouter } from './nominatim/index.js';
 import { router as geoConfigRouter } from './geoconfig/index.js';
 import { router as realtimeRouter } from './realtime-gtfs/index.js';
 import { loadLookupTables } from './lib/route-linestring.js';
+import path from 'path';
 
 
 async function initApp() {
@@ -96,6 +97,10 @@ async function initApp() {
   // TODO: remove in next release
   app.use('/v1/nominatim', nominatimRouter);
   app.use('/api/v1/nominatim', nominatimRouter);
+
+  app.use('/route-tiles', 
+    express.static(path.join(WEB_APP_GEO_CONFIG_FOLDER_CONTAINER_PATH, 'route-tiles'))
+  );
   
   process.on('SIGINT', function() {
     logger.info( "\nGracefully shutting down from SIGINT (Ctrl-C)" );

--- a/src/index.js
+++ b/src/index.js
@@ -100,7 +100,7 @@ async function initApp() {
 
   // Add headers so mapliber-gl decodes protobufs appropriately
   const staticTilesOpts = { 
-    setHeaders: (res, _, _) => {
+    setHeaders: (res, _u1, _u2) => {
       res.setHeader('Content-Encoding', 'gzip');
       res.setHeader('Content-Type', 'application/x-protobuf');
     },

--- a/src/index.js
+++ b/src/index.js
@@ -122,6 +122,11 @@ async function initApp() {
   app.use('/v1/stop-tiles', stopTiles);
   app.use('/api/v1/stop-tiles', stopTiles);
 
+  process.on('SIGINT', function() {
+    logger.info( "\nGracefully shutting down from SIGINT (Ctrl-C)" );
+    // some other closing procedures go here
+    process.exit(0);
+  });
   
   process.on('SIGTERM', function() {
     logger.info( "\nGracefully shutting down from SIGTERM (Ctrl-C)" );

--- a/src/index.js
+++ b/src/index.js
@@ -98,9 +98,9 @@ async function initApp() {
   app.use('/v1/nominatim', nominatimRouter);
   app.use('/api/v1/nominatim', nominatimRouter);
 
-  app.use('/route-tiles', 
-    express.static(path.join(WEB_APP_GEO_CONFIG_FOLDER_CONTAINER_PATH, 'route-tiles'))
-  );
+  const routeTiles = express.static(path.join(WEB_APP_GEO_CONFIG_FOLDER_CONTAINER_PATH, 'route-tiles'));
+  app.use('/v1/route-tiles', routeTiles);
+  app.use('/api/v1/route-tiles', routeTiles);
   
   process.on('SIGINT', function() {
     logger.info( "\nGracefully shutting down from SIGINT (Ctrl-C)" );

--- a/src/index.js
+++ b/src/index.js
@@ -98,15 +98,30 @@ async function initApp() {
   app.use('/v1/nominatim', nominatimRouter);
   app.use('/api/v1/nominatim', nominatimRouter);
 
-  const routeTiles = express.static(path.join(WEB_APP_GEO_CONFIG_FOLDER_CONTAINER_PATH, 'route-tiles'));
+  // Add headers so mapliber-gl decodes protobufs appropriately
+  const staticTilesOpts = { 
+    setHeaders: (res, _, _) => {
+      res.setHeader('Content-Encoding', 'gzip');
+      res.setHeader('Content-Type', 'application/x-protobuf');
+    },
+  };
+
+  // Expose static endpoint for tileset containing route-lines
+  const routeTiles = express.static(
+    path.join(WEB_APP_GEO_CONFIG_FOLDER_CONTAINER_PATH, 'route-tiles'),
+    staticTilesOpts
+  );
   app.use('/v1/route-tiles', routeTiles);
   app.use('/api/v1/route-tiles', routeTiles);
   
-  process.on('SIGINT', function() {
-    logger.info( "\nGracefully shutting down from SIGINT (Ctrl-C)" );
-    // some other closing procedures go here
-    process.exit(0);
-  });
+  // Expose static endpoint for tileset containing stop points
+  const stopTiles = express.static(
+    path.join(WEB_APP_GEO_CONFIG_FOLDER_CONTAINER_PATH, 'stop-tiles'),
+    staticTilesOpts
+  );
+  app.use('/v1/stop-tiles', stopTiles);
+  app.use('/api/v1/stop-tiles', stopTiles);
+
   
   process.on('SIGTERM', function() {
     logger.info( "\nGracefully shutting down from SIGTERM (Ctrl-C)" );

--- a/src/lib/route-linestring.js
+++ b/src/lib/route-linestring.js
@@ -27,6 +27,7 @@ export function replacePtRouteLinesWithHighres(routes) {
   const {
     stopTripShapeLookup,
     shapeIdLineStringLookup,
+    tripIdStopIdsLookup,
   } = lookupTables;
 
   for (const path of routesCopy.paths) {
@@ -38,6 +39,7 @@ export function replacePtRouteLinesWithHighres(routes) {
         const routeId = leg['route_id'];
         const tripId = leg['trip_id'];
         const shapeIdsForRoute = stopTripShapeLookup[routeId];
+        leg['all_stop_ids'] = tripIdStopIdsLookup[tripId];
 
         if (shapeIdsForRoute) {
           const shapeId = shapeIdsForRoute[tripId];

--- a/src/lib/route-linestring.js
+++ b/src/lib/route-linestring.js
@@ -25,7 +25,7 @@ export function replacePtRouteLinesWithHighres(routes) {
 
   const routesCopy = JSON.parse(JSON.stringify(routes));
   const {
-    stopTripShapeLookup,
+    routeTripShapeLookup,
     shapeIdLineStringLookup,
     tripIdStopIdsLookup,
   } = lookupTables;
@@ -38,7 +38,7 @@ export function replacePtRouteLinesWithHighres(routes) {
 
         const routeId = leg['route_id'];
         const tripId = leg['trip_id'];
-        const shapeIdsForRoute = stopTripShapeLookup[routeId];
+        const shapeIdsForRoute = routeTripShapeLookup[routeId];
         leg['all_stop_ids'] = tripIdStopIdsLookup[tripId];
 
         if (shapeIdsForRoute) {


### PR DESCRIPTION
1. Serves up the tilesets generated from `gtfs-processor` with two new static endpoints.
2. Injects a new field into a pt leg, `all_stop_ids`.  This is a `string[]` of all stop-ids on that trip, not just the ones on the route-segment.