### PR TITLE
Add Mapbox params to /config route

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -72,3 +72,6 @@ const DEFAULT_ALERTS_CACHE_TIME_MSEC = 3 * 60 * 1000;
 export const ALERTS_CACHE_TIME_MSEC = (
   process.env.ALERTS_CACHE_TIME_MSEC || DEFAULT_ALERTS_CACHE_TIME_MSEC
 );
+
+export const MAPBOX_ACCESS_TOKEN = isEmpty(process.env.MAPBOX_ACCESS_TOKEN) ? null : process.env.MAPBOX_ACCESS_TOKEN;
+export const MAPBOX_STYLE_URL = isEmpty(process.env.MAPBOX_STYLE_URL) ? null : process.env.MAPBOX_STYLE_URL;

--- a/src/geoconfig/router.js
+++ b/src/geoconfig/router.js
@@ -2,6 +2,8 @@ import express from 'express';
 import { join } from 'node:path';
 import { readFile } from 'node:fs/promises';
 import {
+  MAPBOX_ACCESS_TOKEN,
+  MAPBOX_STYLE_URL,
   REGION_CONFIG,
   WEB_APP_GEO_CONFIG_FOLDER_CONTAINER_PATH,
 } from '../config.js';
@@ -32,6 +34,14 @@ router.get('/', async (req, res) => {
     config.transitServiceArea = transitServiceArea;
   }
   delete config.gtfsRtUrls; // Not used in frontend (can't be, would expose token)
+
+  if (MAPBOX_ACCESS_TOKEN != null) {
+    config.mapboxAccessToken = MAPBOX_ACCESS_TOKEN;
+  }
+
+  if (MAPBOX_STYLE_URL != null) {
+    config.mapboxStyleUrl = MAPBOX_STYLE_URL;
+  }
 
   res.json(config);
 });


### PR DESCRIPTION
Adds Mapbox Access token and style-url to the `api/v1/config` endpoint.

- This would allow `bikehopper-ui` to work standalone without relying on these params to be inlined into the bundle.
- Makes it more convenient tp update it would allow the params to be defined in `gitops`, and refreshable at runtime. Instead of having to be passed down from Github Secrets -> Github Actions ->Docker image being used to build the bundle -> JS Bundle at `bikehopper-ui` build time.